### PR TITLE
YAML Tosca files were modified according to the TOSCA standard

### DIFF
--- a/cloudshell_base_standard.yaml
+++ b/cloudshell_base_standard.yaml
@@ -43,10 +43,12 @@ capability_types:
         type: boolean
         default: false
       Sandbox Function:
+        type: string
         default: resource
         constraints:
           - valid_values: [service,resource]
       Type:
+        type: string
         default: physical
         description: for resources - physical,application. for services- deployment,installation
         constraints:

--- a/cloudshell_networking_standard.yaml
+++ b/cloudshell_networking_standard.yaml
@@ -6,7 +6,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - cloudshell_base_standard.yaml
+  - cloudshell_base_standard: cloudshell_base_standard.yaml
   
 node_types:
 

--- a/cloudshell_networking_standard.yaml
+++ b/cloudshell_networking_standard.yaml
@@ -115,10 +115,10 @@ node_types:
         type: string
     requirements:
       - Ports:
-        capability: tosca.capabilities.Attachment
-        node: cloudshell.nodes.GenericPort
-        relationship: tosca.relationships.AttachesTo
-        occurrences: [0, UNBOUNDED]
+            capability: tosca.capabilities.Attachment
+            node: cloudshell.nodes.GenericPort
+            relationship: tosca.relationships.AttachesTo
+            occurrences: [0, UNBOUNDED]
 
   cloudshell.networking.nodes.GenericPort:
     properties:

--- a/cloudshell_networking_standard.yaml
+++ b/cloudshell_networking_standard.yaml
@@ -127,10 +127,10 @@ node_types:
         type: string
     requirements:
       - Ports:
-        capability: tosca.capabilities.Attachment
-        node: cloudshell.nodes.GenericPort
-        relationship: tosca.relationships.AttachesTo
-        occurrences: [0, UNBOUNDED]
+          capability: tosca.capabilities.Attachment
+          node: cloudshell.nodes.GenericPort
+          relationship: tosca.relationships.AttachesTo
+          occurrences: [0, UNBOUNDED]
     capabilities:
      cloudshell_type:
         type: cloudshell.networking.types.SubModule

--- a/nxos_tosca_sample.yaml
+++ b/nxos_tosca_sample.yaml
@@ -7,7 +7,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - cloudshell_networking_standard.yaml
+  - cloudshell_networking_standard: cloudshell_networking_standard.yaml
  
 node_types:
 


### PR DESCRIPTION
1. type was added in cloudshell_base_standard.yaml
2. indentation was fixed in cloudshell_networking_standard.yaml